### PR TITLE
Refactor authentication layout and user auth form; add index route fo…

### DIFF
--- a/src/web/src/features/auth/auth-layout.tsx
+++ b/src/web/src/features/auth/auth-layout.tsx
@@ -4,13 +4,8 @@ interface Props {
 
 export default function AuthLayout({ children }: Props) {
   return (
-    <div className="bg-primary-foreground container grid h-svh max-w-none items-center justify-center">
-      <div className="mx-auto flex w-full flex-col justify-center space-y-2 py-8 sm:w-[480px] sm:p-8">
-        <div className="mb-4 flex items-center justify-center">
-          <h1 className="text-3xl font-semibold">Noah Garden HOA</h1>
-        </div>
-        {children}
-      </div>
+    <div className="bg-muted/30 min-h-screen flex flex-col items-center justify-center p-4">
+      {children}
     </div>
   );
 }

--- a/src/web/src/features/auth/sign-in/components/user-auth-form.tsx
+++ b/src/web/src/features/auth/sign-in/components/user-auth-form.tsx
@@ -18,7 +18,6 @@ import api from "@/lib/api";
 import { useAuthStore, type User } from "@/stores/auth-store";
 import { router } from "@/QueryClient";
 import { Alert, AlertTitle } from "@/components/ui/alert";
-import { Link } from "@tanstack/react-router";
 import { AlertCircleIcon } from "lucide-react";
 
 const formSchema = z.object({
@@ -123,18 +122,12 @@ export function UserAuthForm() {
           control={form.control}
           name="password"
           render={({ field }) => (
-            <FormItem className="relative">
+            <FormItem>
               <FormLabel>Password</FormLabel>
               <FormControl>
                 <PasswordInput placeholder="********" {...field} />
               </FormControl>
               <FormMessage />
-              <Link
-                to="/admin"
-                className="text-muted-foreground absolute -top-0.5 right-0 text-sm font-medium hover:opacity-75"
-              >
-                Forgot password?
-              </Link>
             </FormItem>
           )}
         />

--- a/src/web/src/features/auth/sign-in/index.tsx
+++ b/src/web/src/features/auth/sign-in/index.tsx
@@ -16,13 +16,13 @@ import { Route } from "@/routes/(auth)/sign-in";
 export default function SignIn() {
   const { user, initAuth } = useAuthStore();
   const { redirect } = Route.useSearch();
-  const [ loading, setLoading ] = useState(false);
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     const checkAuth = async () => {
       if (!user) {
         setLoading(true);
-        await initAuth(redirect as string); 
+        await initAuth(redirect as string);
         setLoading(false);
       } else {
         router.navigate({ to: (redirect as string) || `/${user.role}` });
@@ -32,7 +32,7 @@ export default function SignIn() {
     checkAuth();
   }, [user, initAuth, redirect]);
 
-  if(loading) {
+  if (loading) {
     return (
       <div className="fixed top-4 left-4 flex items-center space-x-2">
         <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
@@ -43,31 +43,17 @@ export default function SignIn() {
 
   return (
     <AuthLayout>
-      <Card className="gap-4">
-        <CardHeader className="flex flex-col items-center text-center">
-          <CardTitle className="text-lg tracking-tight">Sign In</CardTitle>
-          <CardDescription>Sign In in to start your session.</CardDescription>
+      <Card className="w-full max-w-sm shadow-lg border-border">
+        <CardHeader className="items-center text-center">
+          <CardTitle className="text-2xl font-bold">Noah Garden HOA</CardTitle>
+          <CardDescription>Sign in to continue</CardDescription>
         </CardHeader>
         <CardContent>
           <UserAuthForm />
         </CardContent>
-        <CardFooter>
-          <p className="text-muted-foreground px-8 text-center text-sm">
-            By clicking Sign In, you agree to our{" "}
-            <a
-              href="/terms"
-              className="hover:text-primary underline underline-offset-4"
-            >
-              Terms of Service
-            </a>{" "}
-            and{" "}
-            <a
-              href="/privacy"
-              className="hover:text-primary underline underline-offset-4"
-            >
-              Privacy Policy
-            </a>
-            .
+        <CardFooter className="flex justify-center border-t bg-muted/30 pt-4">
+          <p className="text-xs text-muted-foreground/60">
+            Restricted Access &bull; Noah Garden HOA
           </p>
         </CardFooter>
       </Card>

--- a/src/web/src/routeTree.gen.ts
+++ b/src/web/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as IndexRouteImport } from './routes/index'
 import { Route as errors503RouteImport } from './routes/(errors)/503'
 import { Route as errors500RouteImport } from './routes/(errors)/500'
 import { Route as errors404RouteImport } from './routes/(errors)/404'
@@ -34,6 +35,11 @@ import { Route as AuthenticatedAdminFinancialsFeesFeeIdRouteImport } from './rou
 import { Route as AuthenticatedAdminUnitsUnitIdLeasesIndexRouteImport } from './routes/_authenticated/admin/units/$unitId/leases/index'
 import { Route as AuthenticatedAdminUnitsUnitIdLeasesLeaseIdIndexRouteImport } from './routes/_authenticated/admin/units/$unitId/leases/$leaseId/index'
 
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const errors503Route = errors503RouteImport.update({
   id: '/(errors)/503',
   path: '/503',
@@ -172,6 +178,7 @@ const AuthenticatedAdminUnitsUnitIdLeasesLeaseIdIndexRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
+  '/': typeof IndexRoute
   '/admin': typeof AuthenticatedAdminRouteRouteWithChildren
   '/sign-in': typeof authSignInRoute
   '/401': typeof errors401Route
@@ -198,6 +205,7 @@ export interface FileRoutesByFullPath {
   '/admin/units/$unitId/leases/$leaseId': typeof AuthenticatedAdminUnitsUnitIdLeasesLeaseIdIndexRoute
 }
 export interface FileRoutesByTo {
+  '/': typeof IndexRoute
   '/sign-in': typeof authSignInRoute
   '/401': typeof errors401Route
   '/403': typeof errors403Route
@@ -224,6 +232,7 @@ export interface FileRoutesByTo {
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
   '/_authenticated/admin': typeof AuthenticatedAdminRouteRouteWithChildren
   '/(auth)/sign-in': typeof authSignInRoute
   '/(errors)/401': typeof errors401Route
@@ -252,6 +261,7 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
+    | '/'
     | '/admin'
     | '/sign-in'
     | '/401'
@@ -278,6 +288,7 @@ export interface FileRouteTypes {
     | '/admin/units/$unitId/leases/$leaseId'
   fileRoutesByTo: FileRoutesByTo
   to:
+    | '/'
     | '/sign-in'
     | '/401'
     | '/403'
@@ -303,6 +314,7 @@ export interface FileRouteTypes {
     | '/admin/units/$unitId/leases/$leaseId'
   id:
     | '__root__'
+    | '/'
     | '/_authenticated/admin'
     | '/(auth)/sign-in'
     | '/(errors)/401'
@@ -330,6 +342,7 @@ export interface FileRouteTypes {
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
+  IndexRoute: typeof IndexRoute
   AuthenticatedAdminRouteRoute: typeof AuthenticatedAdminRouteRouteWithChildren
   authSignInRoute: typeof authSignInRoute
   errors401Route: typeof errors401Route
@@ -341,6 +354,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/(errors)/503': {
       id: '/(errors)/503'
       path: '/503'
@@ -572,6 +592,7 @@ const AuthenticatedAdminRouteRouteWithChildren =
   )
 
 const rootRouteChildren: RootRouteChildren = {
+  IndexRoute: IndexRoute,
   AuthenticatedAdminRouteRoute: AuthenticatedAdminRouteRouteWithChildren,
   authSignInRoute: authSignInRoute,
   errors401Route: errors401Route,

--- a/src/web/src/routes/index.tsx
+++ b/src/web/src/routes/index.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/')({
+    beforeLoad: () => {
+        throw redirect({
+            to: '/sign-in',
+            search: { redirect: null },
+        })
+    },
+})


### PR DESCRIPTION
### ✅ Changes
- Redirect `/` based on auth state:
  - Authenticated → **Dashboard**
  - Unauthenticated → **Login**
- Fix login header text visibility (**“Noah Garden HOA”**) in dark mode using theme-aware background
- Remove **Privacy Policy** text
- Add **Restricted Access** text to improve card layout/height

---

### 🧪 Testing
- Verified redirects for authenticated and unauthenticated users
- Checked login page in light and dark mode
- No issue on build

---

### 🖼️ Screenshots
**Before**
<img width="814" height="679" alt="Image" src="https://github.com/user-attachments/assets/b4df4990-90d3-40f5-9ee4-ad1ebab3dc43" />

**After**
<img width="814" height="679" alt="Image" src="https://github.com/user-attachments/assets/bfc906f6-a0fd-40d5-8868-f9125a17c68a" />

---

Closes #46
