### PR TITLE
Refactor global input styles for input, textarea, and select styles

### DIFF
--- a/src/web/src/components/data-table/data-table.tsx
+++ b/src/web/src/components/data-table/data-table.tsx
@@ -49,9 +49,9 @@ export function DataTable<TData>({
                       {header.isPlaceholder
                         ? null
                         : flexRender(
-                            header.column.columnDef.header,
-                            header.getContext()
-                          )}
+                          header.column.columnDef.header,
+                          header.getContext()
+                        )}
                     </TableHead>
                   );
                 })}

--- a/src/web/src/components/ui/command.tsx
+++ b/src/web/src/components/ui/command.tsx
@@ -52,7 +52,7 @@ function CommandDialog({
         className={cn("overflow-hidden p-0", className)}
         showCloseButton={showCloseButton}
       >
-        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command className="**:[[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 **:[[cmdk-input]]:h-12 **:[[cmdk-item]]:px-2 **:[[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5 border-0">
           {children}
         </Command>
       </DialogContent>
@@ -118,7 +118,7 @@ function CommandGroup({
     <CommandPrimitive.Group
       data-slot="command-group"
       className={cn(
-        "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
+        "text-foreground **:[[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium",
         className
       )}
       {...props}

--- a/src/web/src/components/ui/input.tsx
+++ b/src/web/src/components/ui/input.tsx
@@ -8,8 +8,8 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground h-9 w-full min-w-0 rounded-md border border-border bg-input text-foreground px-3 py-2 text-base shadow-xs outline-none transition-colors duration-200 file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus:outline-none focus:ring-2 focus:ring-ring focus:border-primary",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className
       )}

--- a/src/web/src/components/ui/select.tsx
+++ b/src/web/src/components/ui/select.tsx
@@ -35,7 +35,8 @@ function SelectTrigger({
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex w-fit items-center justify-between gap-2 rounded-md border border-border bg-input text-foreground px-3 py-2 text-sm whitespace-nowrap shadow-xs outline-none transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "focus:outline-none focus:ring-2 focus:ring-ring focus:border-primary",
         className
       )}
       {...props}
@@ -62,7 +63,7 @@ function SelectContent({
         className={cn(
           "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
           position === "popper" &&
-            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className
         )}
         position={position}
@@ -74,7 +75,7 @@ function SelectContent({
           className={cn(
             "p-1",
             position === "popper" &&
-              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
           )}
         >
           {children}

--- a/src/web/src/components/ui/textarea.tsx
+++ b/src/web/src/components/ui/textarea.tsx
@@ -7,7 +7,8 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "placeholder:text-muted-foreground aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-md border border-border bg-input text-foreground px-3 py-2 text-base shadow-xs outline-none transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "focus:outline-none focus:ring-2 focus:ring-ring focus:border-primary",
         className
       )}
       {...props}

--- a/src/web/src/index.css
+++ b/src/web/src/index.css
@@ -47,141 +47,139 @@
   /* =========================
      Core surfaces (bright, clean)
      ========================= */
-  --background: #FFFCF6;            /* warm ivory (reduces "white fatigue") */
-  --foreground: #111827;            /* ink */
-  --card: #FFFFFF;
+  --background: #fffcf6; /* warm ivory (reduces "white fatigue") */
+  --foreground: #111827; /* ink */
+  --card: #ffffff;
   --card-foreground: #111827;
-  --popover: #FFF8E6;               /* soft warm popover */
+  --popover: #fff8e6; /* soft warm popover */
   --popover-foreground: #111827;
 
   /* =========================
      Brand (GOLD) — primary actions, active states, highlights
      ========================= */
-  --primary: #D4AF37;               /* gold */
-  --primary-foreground: #1A1300;    /* deep warm ink for readability on gold */
-  --ring: #D4AF37;
+  --primary: #d4af37; /* gold */
+  --primary-foreground: #1a1300; /* deep warm ink for readability on gold */
+  --ring: #d4af37;
 
   /* =========================
      Colorful secondary system
      - secondary is used by shadcn for subtle variants
      - accent is used for highlights, hovers, tags
      ========================= */
-  --secondary: #1D4ED8;             /* royal blue (pairs well with gold) */
-  --secondary-foreground: #FFFFFF;
+  --secondary: #1d4ed8; /* royal blue (pairs well with gold) */
+  --secondary-foreground: #ffffff;
 
-  --accent: #14B8A6;                /* teal (fresh, modern with gold) */
-  --accent-foreground: #062B2A;
+  --accent: #14b8a6; /* teal (fresh, modern with gold) */
+  --accent-foreground: #062b2a;
 
-  --muted: #F3F4F6;
-  --muted-foreground: #6B7280;
+  --muted: #f3f4f6;
+  --muted-foreground: #6b7280;
 
   /* =========================
      Status
      ========================= */
-  --destructive: #EF4444;
-  --success: #10B981;
-  --warning: #F59E0B;
+  --destructive: #ef4444;
+  --success: #10b981;
+  --warning: #f59e0b;
 
   /* =========================
      Borders / Inputs
      ========================= */
-  --border: #E7E2D6;                /* warm gray border */
-  --input: #FFFEFB;
+  --border: #e7e2d6; /* warm gray border */
+  --input: #fffefb;
 
   /* =========================
      Sidebar (distinct color)
      ========================= */
-  --sidebar: #0B1B34;               /* deep navy */
-  --sidebar-foreground: #F9FAFB;
+  --sidebar: #0b1b34; /* deep navy */
+  --sidebar-foreground: #f9fafb;
 
-  --sidebar-primary: #D4AF37;       /* active item uses gold */
-  --sidebar-primary-foreground: #1A1300;
+  --sidebar-primary: #d4af37; /* active item uses gold */
+  --sidebar-primary-foreground: #1a1300;
 
-  --sidebar-accent: #1D4ED8;        /* hover uses royal blue */
-  --sidebar-accent-foreground: #FFFFFF;
+  --sidebar-accent: #1d4ed8; /* hover uses royal blue */
+  --sidebar-accent-foreground: #ffffff;
 
-  --sidebar-border: #1F2A44;
-  --sidebar-ring: #D4AF37;
+  --sidebar-border: #1f2a44;
+  --sidebar-ring: #d4af37;
 
   /* =========================
      Charts (vivid, readable)
      ========================= */
-  --chart-1: #D4AF37;               /* gold */
-  --chart-2: #1D4ED8;               /* royal blue */
-  --chart-3: #14B8A6;               /* teal */
-  --chart-4: #A855F7;               /* violet */
-  --chart-5: #F97316;               /* orange */
+  --chart-1: #d4af37; /* gold */
+  --chart-2: #1d4ed8; /* royal blue */
+  --chart-3: #14b8a6; /* teal */
+  --chart-4: #a855f7; /* violet */
+  --chart-5: #f97316; /* orange */
 }
 
 .dark {
   /* =========================
      Core surfaces (dark, rich)
      ========================= */
-  --background: #07111F;            /* deep navy-black */
-  --foreground: #F8FAFC;
-  --card: #0B1B34;                  /* navy card */
-  --card-foreground: #F8FAFC;
-  --popover: #0A162B;
-  --popover-foreground: #F8FAFC;
+  --background: #07111f; /* deep navy-black */
+  --foreground: #f8fafc;
+  --card: #0b1b34; /* navy card */
+  --card-foreground: #f8fafc;
+  --popover: #0a162b;
+  --popover-foreground: #f8fafc;
 
   /* =========================
      Brand (GOLD)
      ========================= */
-  --primary: #E6C35C;               /* brighter gold for dark mode */
-  --primary-foreground: #1A1300;
-  --ring: #E6C35C;
+  --primary: #e6c35c; /* brighter gold for dark mode */
+  --primary-foreground: #1a1300;
+  --ring: #e6c35c;
 
   /* =========================
      Secondary & accent
      ========================= */
-  --secondary: #3B82F6;             /* bright blue */
-  --secondary-foreground: #07111F;
+  --secondary: #3b82f6; /* bright blue */
+  --secondary-foreground: #07111f;
 
-  --accent: #2DD4BF;                /* bright teal */
-  --accent-foreground: #062B2A;
+  --accent: #2dd4bf; /* bright teal */
+  --accent-foreground: #062b2a;
 
-  --muted: #0E223F;
-  --muted-foreground: #C7D2E0;
+  --muted: #0e223f;
+  --muted-foreground: #c7d2e0;
 
   /* =========================
      Status
      ========================= */
-  --destructive: #F87171;
-  --success: #34D399;
-  --warning: #FBBF24;
+  --destructive: #f87171;
+  --success: #34d399;
+  --warning: #fbbf24;
 
   /* =========================
      Borders / Inputs
      ========================= */
-  --border: #13284A;
-  --input: #0A162B;
+  --border: #13284a;
+  --input: #0a162b;
 
   /* =========================
      Sidebar (distinct color)
      ========================= */
-  --sidebar: #0A162B;               /* slightly different from background */
-  --sidebar-foreground: #F8FAFC;
+  --sidebar: #0a162b; /* slightly different from background */
+  --sidebar-foreground: #f8fafc;
 
-  --sidebar-primary: #E6C35C;       /* gold active item */
-  --sidebar-primary-foreground: #1A1300;
+  --sidebar-primary: #e6c35c; /* gold active item */
+  --sidebar-primary-foreground: #1a1300;
 
-  --sidebar-accent: #3B82F6;        /* hover blue */
-  --sidebar-accent-foreground: #07111F;
+  --sidebar-accent: #3b82f6; /* hover blue */
+  --sidebar-accent-foreground: #07111f;
 
-  --sidebar-border: #13284A;
-  --sidebar-ring: #E6C35C;
+  --sidebar-border: #13284a;
+  --sidebar-ring: #e6c35c;
 
   /* =========================
      Charts
      ========================= */
-  --chart-1: #E6C35C;
-  --chart-2: #60A5FA;
-  --chart-3: #2DD4BF;
-  --chart-4: #C084FC;
-  --chart-5: #FB923C;
+  --chart-1: #e6c35c;
+  --chart-2: #60a5fa;
+  --chart-3: #2dd4bf;
+  --chart-4: #c084fc;
+  --chart-5: #fb923c;
 }
-
-
 
 @layer base {
   * {
@@ -192,8 +190,10 @@
   }
 }
 
+/* Commented out: styles moved to individual shadcn components (Input, Textarea, Select)
 input,
 textarea,
 select {
   @apply border border-border rounded-md bg-input text-foreground px-3 py-2 outline-none focus:outline-none focus:ring-2 focus:ring-ring focus:border-primary transition-colors duration-200;
 }
+*/


### PR DESCRIPTION
This PR refactors global input styling in `index.css` and separates styles into **component-specific styles** for `Input`, `Textarea`, and `Select`. It ensures Shadcn component variants work correctly and maintains consistent styling across the app.

---

### ✅ Changes

* Removed hard-coded global styles for form elements in `index.css`
* Added component-specific styles for:

  * `Input`
  * `Textarea`
  * `Select`
* Verified all Shadcn variant styles apply correctly
* Ensured consistent look across light/dark themes

---

### 🧪 Testing

* Checked `Input`, `Textarea`, `Select` in different components
* Verified Shadcn variants (default, outline, error, etc.) still work
* Ensured no regression in dark/light mode

---

### 🖼️ Screenshots (Examples of changes / fixed issue)
**Before**
<img width="503" height="376" alt="image" src="https://github.com/user-attachments/assets/3e276717-a9ea-45ed-a4ea-99ad4baadedf" />

**After**
<img width="503" height="376" alt="image" src="https://github.com/user-attachments/assets/253f5c7e-d6df-4e99-8b2f-cf9f53771cda" />

---

### 🔗 Related Issue

Closes #48