### PR TITLE
Fix: Breadcrumb not updating on navigation

### DIFF
--- a/src/web/src/components/dynamic-breadcrumb.tsx
+++ b/src/web/src/components/dynamic-breadcrumb.tsx
@@ -14,7 +14,7 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { Link } from "@tanstack/react-router"
+import { Link, useLocation } from "@tanstack/react-router"
 import { Fragment } from "react/jsx-runtime"
 
 // Custom labels for specific paths
@@ -97,7 +97,8 @@ const LOCALES = ['en', 'nl']
 const LAYOUT_SEGMENTS = ['admin']
 
 export function DynamicBreadcrumb() {
-    const pathname = window.location.pathname
+    const location = useLocation()
+    const pathname = location.pathname
 
     // Filter out empty strings, locales, and layout segments
     const allPaths = pathname.split('/').filter((path) => path !== "" && !LOCALES.includes(path))


### PR DESCRIPTION
The `DynamicBreadcrumb` component was using `window.location.pathname` to get the current route, which only reads the pathname once during component render. This caused the breadcrumb to remain static when navigating between routes, only updating after a full page reload.

## Solution
- Replaced `window.location.pathname` with TanStack Router's `useLocation()` hook
- Added `useLocation` to the imports from `@tanstack/react-router`
- The hook automatically subscribes to route changes, ensuring the breadcrumb updates reactively

## Changes
- **File**: `src/web/src/components/dynamic-breadcrumb.tsx`
  - Added `useLocation` to imports
  - Changed from `const pathname = window.location.pathname` to using `useLocation().pathname`

## Testing
- [x] Navigate between different routes and verify breadcrumb updates immediately
- [x] Verify breadcrumb still works correctly on page reload
- [x] Test with nested routes and dynamic IDs

## Related
Fixes #56